### PR TITLE
Bump Werkzeug to 3.1.6 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask==2.3.3
 Flask-SocketIO==5.3.6
 python-socketio[client]==5.8.0
 python-engineio==4.7.1
-Werkzeug==3.0.6
+Werkzeug==3.1.6
 
 # Video processing
 opencv-python==4.8.1.78


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `Werkzeug` `3.0.6` → `3.1.6`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:**  Werkzeug safe_join() allows Windows special device names CVE-2025-66221, CVE-2026-21860, CVE-2026-27199

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `34d98e1043562f14` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"34d98e1043562f14","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->