### PR TITLE
Bump python-dotenv to 1.2.2 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Pillow>=9.0.0
 psutil==5.9.5
 
 # Environment and utilities
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 python-magic==0.4.27
 
 # Video downloading


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `python-dotenv` `1.0.0` → `1.2.2`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:** python-dotenv: Symlink following in set_key allows arbitrary file overwrite via cross-device rename fallback CVE-2026-28684

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `ecf69b91999e7a76` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"ecf69b91999e7a76","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->