### PR TITLE
Bump pytest to 9.0.3 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ gevent-websocket==0.10.1
 gunicorn==23.0.0
 
 # Development and testing (optional)
-pytest==7.4.2
+pytest==9.0.3
 pytest-cov==4.1.0
 black==24.3.0
 flake8==6.1.0


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `pytest` `7.4.2` → `9.0.3`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:** pytest has vulnerable tmpdir handling CVE-2025-71176

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `c4a1aa5039949af6` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"c4a1aa5039949af6","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->